### PR TITLE
feat(contract): adjust fixed point math

### DIFF
--- a/contracts/partials/farm/constants.religo
+++ b/contracts/partials/farm/constants.religo
@@ -1,2 +1,1 @@
-let fixedPointAccuracy =   1_000_000_000_000n; // 12 decimals
-let fixedPointAccuracy21 = 1_000_000_000_000_000_000_000n; //21 decimals
+let fixedPointAccuracy = 1_000_000n; // 6 decimals

--- a/decimals-config.json
+++ b/decimals-config.json
@@ -1,5 +1,5 @@
 {
-    "fixedPointAccuracy": 1000000000000,
+    "fixedPointAccuracy": 1000000,
     "rewardToken": 1000000000000000000,
-    "lpToken": 1000000000
+    "lpToken": 1000000
 }

--- a/test/helpers/updatePool.ts
+++ b/test/helpers/updatePool.ts
@@ -34,4 +34,3 @@ export function updateAccumulatedRewardPerShare(initialStorage: mockContractStor
     
     return previousAcc.plus(newRewardPerShare)
 }
-

--- a/test/unit/claim/claim.ts
+++ b/test/unit/claim/claim.ts
@@ -41,7 +41,7 @@ contract('%claim', () => {
         
             it('calculates accumulated reward per share', async () => {
                 const accumulatedRewardPerShare = await farmContract.getAccumulatedRewardPerShare()
-                expect(accumulatedRewardPerShare.toFixed()).to.equal('150000000000000000000');
+                expect(accumulatedRewardPerShare.toFixed()).to.equal('150000000000000000');
             });
 
             it('calculates delegator reward', async () => {
@@ -86,7 +86,7 @@ contract('%claim', () => {
 
                 it('calculates accumulated reward per share', async () => {
                     const accumulatedRewardPerShare = await farmContract.getAccumulatedRewardPerShare()
-                    expect(accumulatedRewardPerShare.toFixed()).to.equal('200000000000000000000');
+                    expect(accumulatedRewardPerShare.toFixed()).to.equal('200000000000000000');
                 })
 
                 it('calculates delegator reward', async () => {
@@ -151,7 +151,7 @@ contract('%claim', () => {
 
                 it('calculates accumulated reward per share', async () => {
                     const accumulatedRewardPerShare = await farmContract.getAccumulatedRewardPerShare()
-                    expect(accumulatedRewardPerShare.toFixed()).to.equal('75000000000000000000');
+                    expect(accumulatedRewardPerShare.toFixed()).to.equal('75000000000000000');
                 });
 
                 it('calculates delegator reward', async () => {


### PR DESCRIPTION
LP tokens have 6 decimals, where the example reward token has 18 decimals